### PR TITLE
Fix docs, app error middleware, add example env and backend test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We love your input! We want to make contributing to Video Automation SaaS as eas
 - Proposing new features
 - Becoming a maintainer
 
-## We Develop with Github
+## We Develop with GitHub
 
 We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/server.js",
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/server.ts",
     "lint": "eslint . --ext .ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": ["video", "automation", "saas", "api"],
   "author": "",
@@ -30,6 +30,10 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
-    "eslint": "^9.26.0"
+    "eslint": "^9.26.0",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,12 +22,13 @@ app.use('/api/v1', (req: Request, res: Response) => {
 });
 
 // Error handling middleware
-app.use((err: Error, req: Request, res: Response) => {
+app.use((err: Error, req: Request, res: Response, next: express.NextFunction) => {
   console.error(err.stack);
-  res.status(500).json({ 
+  res.status(500).json({
     error: 'Internal Server Error',
     message: process.env.NODE_ENV === 'development' ? err.message : undefined
   });
+  next();
 });
 
 export default app;

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../src/app';
+
+describe('GET /health', () => {
+  it('returns ok status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for the frontend
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3001/api/v1


### PR DESCRIPTION
## Summary
- fix Github typo in contributing guide
- implement express error handler correctly
- add example env file for frontend
- configure Jest and add health check test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab6171e4832faea21409da33d6d7